### PR TITLE
VM-559 transparentMask prop added

### DIFF
--- a/datepicker.js
+++ b/datepicker.js
@@ -378,9 +378,10 @@ class DatePicker extends Component {
               style={{flex: 1}}
             >
               <TouchableComponent
-                style={Style.datePickerMask}
+                style={[Style.datePickerMask,
+                this.props.transparentMask ? {backgroundColor: '#00000000'} : {backgroundColor: '#00000077'}]}
                 activeOpacity={1}
-                underlayColor={'#00000077'}
+                underlayColor={this.props.transparentMask ? '#00000000' : '#00000077'}
                 onPress={this.onPressMask}
               >
                 <TouchableComponent
@@ -485,6 +486,7 @@ DatePicker.propTypes = {
   onCloseModal: PropTypes.func,
   onPressMask: PropTypes.func,
   placeholder: PropTypes.string,
+  transparentMask: PropTypes.bool,
   modalOnResponderTerminationRequest: PropTypes.func,
   is24Hour: PropTypes.bool,
   getDateStr: PropTypes.func,


### PR DESCRIPTION
Added transparentMask prop to react-native-datepicker 
1 - To achieve white background when date picker is active 
2 - Right now we don't have access from library to change the background when date picker is active.